### PR TITLE
Fixed warning apc_clear_cache

### DIFF
--- a/polyfill.php
+++ b/polyfill.php
@@ -24,7 +24,7 @@ if (function_exists('apcu_cas') && !function_exists('apc_cas')) {
 if (function_exists('apcu_clear_cache') && !function_exists('apc_clear_cache')) {
     function apc_clear_cache($cache_type = "")
     {
-        return apcu_clear_cache($cache_type);
+        return apcu_clear_cache();
     }
 }
 


### PR DESCRIPTION
apcu_clear_cache has no parameter and gives a warning if you pass one anyway
https://secure.php.net/manual/en/function.apcu-clear-cache.php
